### PR TITLE
Manage ENOTFOUND error on request

### DIFF
--- a/library/export/apidae.js
+++ b/library/export/apidae.js
@@ -162,6 +162,18 @@ class Apidae
           }
         });
       });
+
+      req.on('error', function (err) {
+        console.error('Request error:', err);
+        if (err.code === 'ENOTFOUND') {
+          console.error('DNS lookup failed for:', options.hostname || options.host);
+        }
+        if (callback) {
+          setTimeout(() => {
+            this.__getSitraToken(product, member, callback);
+          }, 15000);
+        }
+      });
   
       req.end();
     }


### PR DESCRIPTION
To avoid application crash on DNS error, catch the error, wait 15s and request a new accessToken.

node:events:346
      throw er; // Unhandled 'error' event
      ^

Error: getaddrinfo ENOTFOUND api.apidae-tourisme.com
    at GetAddrInfoReqWrap.onlookup [as oncomplete] (node:dns:69:26)
    